### PR TITLE
правильные ссылки на travis-ci, ссылки на русскую документацию underscore.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@
         <td style="line-height: 18px;">
           <i>Последняя версия из репозитория, используйте на свой страх и риск</i>
           <a class="travis-badge" href="https://travis-ci.org/documentcloud/backbone">
-            <img src="https://travis-ci.org/documentcloud/backbone.png" />
+            <img src="https://travis-ci.org/jashkenas/backbone.png" />
           </a>
         </td>
       </tr>
@@ -541,7 +541,7 @@
 
     <p>
       Единственная жесткая зависимость в Backbone —
-      <a href="http://underscorejs.org/">Underscore.js</a> <small>( >= 1.4.3)</small>.
+      <a href="http://underscorejs.ru/">Underscore.js</a> <small>( >= 1.4.3)</small>.
       Для RESTful-персистентности, поддержки истории с помощью <a href="#Router">Backbone.Router</a>
       и операций с DOM в <a href="#View">Backbone.View</a>, подключите
       <a href="https://github.com/douglascrockford/JSON-js">json2.js</a>, и либо
@@ -1249,12 +1249,12 @@ book.destroy({success: function(model, response) {
     </p>
 
     <ul class="small">
-      <li><a href="http://underscorejs.org/#keys">keys</a></li>
-      <li><a href="http://underscorejs.org/#values">values</a></li>
-      <li><a href="http://underscorejs.org/#pairs">pairs</a></li>
-      <li><a href="http://underscorejs.org/#invert">invert</a></li>
-      <li><a href="http://underscorejs.org/#pick">pick</a></li>
-      <li><a href="http://underscorejs.org/#omit">omit</a></li>
+      <li><a href="http://underscorejs.ru/#keys">keys</a></li>
+      <li><a href="http://underscorejs.ru/#values">values</a></li>
+      <li><a href="http://underscorejs.ru/#pairs">pairs</a></li>
+      <li><a href="http://underscorejs.ru/#invert">invert</a></li>
+      <li><a href="http://underscorejs.ru/#pick">pick</a></li>
+      <li><a href="http://underscorejs.ru/#omit">omit</a></li>
     </ul>
 
 <pre>
@@ -1587,34 +1587,34 @@ alert(JSON.stringify(collection));
     </p>
 
     <ul class="small">
-      <li><a href="http://underscorejs.org/#each">forEach (each)</a></li>
-      <li><a href="http://underscorejs.org/#map">map (collect)</a></li>
-      <li><a href="http://underscorejs.org/#reduce">reduce (foldl, inject)</a></li>
-      <li><a href="http://underscorejs.org/#reduceRight">reduceRight (foldr)</a></li>
-      <li><a href="http://underscorejs.org/#find">find (detect)</a></li>
-      <li><a href="http://underscorejs.org/#filter">filter (select)</a></li>
-      <li><a href="http://underscorejs.org/#reject">reject</a></li>
-      <li><a href="http://underscorejs.org/#every">every (all)</a></li>
-      <li><a href="http://underscorejs.org/#some">some (any)</a></li>
-      <li><a href="http://underscorejs.org/#contains">contains (include)</a></li>
-      <li><a href="http://underscorejs.org/#invoke">invoke</a></li>
-      <li><a href="http://underscorejs.org/#max">max</a></li>
-      <li><a href="http://underscorejs.org/#min">min</a></li>
-      <li><a href="http://underscorejs.org/#sortBy">sortBy</a></li>
-      <li><a href="http://underscorejs.org/#groupBy">groupBy</a></li>
-      <li><a href="http://underscorejs.org/#sortedIndex">sortedIndex</a></li>
-      <li><a href="http://underscorejs.org/#shuffle">shuffle</a></li>
-      <li><a href="http://underscorejs.org/#toArray">toArray</a></li>
-      <li><a href="http://underscorejs.org/#size">size</a></li>
-      <li><a href="http://underscorejs.org/#first">first (head, take)</a></li>
-      <li><a href="http://underscorejs.org/#initial">initial</a></li>
-      <li><a href="http://underscorejs.org/#rest">rest (tail)</a></li>
-      <li><a href="http://underscorejs.org/#last">last</a></li>
-      <li><a href="http://underscorejs.org/#without">without</a></li>
-      <li><a href="http://underscorejs.org/#indexOf">indexOf</a></li>
-      <li><a href="http://underscorejs.org/#lastIndexOf">lastIndexOf</a></li>
-      <li><a href="http://underscorejs.org/#isEmpty">isEmpty</a></li>
-      <li><a href="http://underscorejs.org/#chain">chain</a></li>
+      <li><a href="http://underscorejs.ru/#each">forEach (each)</a></li>
+      <li><a href="http://underscorejs.ru/#map">map (collect)</a></li>
+      <li><a href="http://underscorejs.ru/#reduce">reduce (foldl, inject)</a></li>
+      <li><a href="http://underscorejs.ru/#reduceRight">reduceRight (foldr)</a></li>
+      <li><a href="http://underscorejs.ru/#find">find (detect)</a></li>
+      <li><a href="http://underscorejs.ru/#filter">filter (select)</a></li>
+      <li><a href="http://underscorejs.ru/#reject">reject</a></li>
+      <li><a href="http://underscorejs.ru/#every">every (all)</a></li>
+      <li><a href="http://underscorejs.ru/#some">some (any)</a></li>
+      <li><a href="http://underscorejs.ru/#contains">contains (include)</a></li>
+      <li><a href="http://underscorejs.ru/#invoke">invoke</a></li>
+      <li><a href="http://underscorejs.ru/#max">max</a></li>
+      <li><a href="http://underscorejs.ru/#min">min</a></li>
+      <li><a href="http://underscorejs.ru/#sortBy">sortBy</a></li>
+      <li><a href="http://underscorejs.ru/#groupBy">groupBy</a></li>
+      <li><a href="http://underscorejs.ru/#sortedIndex">sortedIndex</a></li>
+      <li><a href="http://underscorejs.ru/#shuffle">shuffle</a></li>
+      <li><a href="http://underscorejs.ru/#toArray">toArray</a></li>
+      <li><a href="http://underscorejs.ru/#size">size</a></li>
+      <li><a href="http://underscorejs.ru/#first">first (head, take)</a></li>
+      <li><a href="http://underscorejs.ru/#initial">initial</a></li>
+      <li><a href="http://underscorejs.ru/#rest">rest (tail)</a></li>
+      <li><a href="http://underscorejs.ru/#last">last</a></li>
+      <li><a href="http://underscorejs.ru/#without">without</a></li>
+      <li><a href="http://underscorejs.ru/#indexOf">indexOf</a></li>
+      <li><a href="http://underscorejs.ru/#lastIndexOf">lastIndexOf</a></li>
+      <li><a href="http://underscorejs.ru/#isEmpty">isEmpty</a></li>
+      <li><a href="http://underscorejs.ru/#chain">chain</a></li>
     </ul>
 
 <pre>
@@ -1789,7 +1789,7 @@ var book = library.get(110);
       коллекцию в отсортированном виде. Это означает, что когда модели добавляются,
       они вставляются по корректному индексу в <tt>collection.models</tt>.
       <tt>comparator</tt> может быть определён как функция, подходящая для
-      <a href="http://underscorejs.org/#sortBy">sortBy</a> из Underscore
+      <a href="http://underscorejs.ru/#sortBy">sortBy</a> из Underscore
       (функция одного аргумента), или как функция, подходящая для
       <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort">Array.sort</a>
       (функция двух аргументов), а также может быть определён как строка, указывающая атрибут для сортировки.
@@ -2538,8 +2538,8 @@ var Bookmark = Backbone.View.extend({
       <a href="http://github.com/janl/mustache.js">Mustache.js</a>,
       <a href="http://github.com/creationix/haml-js">Haml-js</a> и
       <a href="http://github.com/sstephenson/eco">Eco</a> являются хорошими альтернативами.
-      Так как на странице уже присутствует <a href="http://underscorejs.org/">Underscore.js</a>,
-      доступная функция <a href="http://underscorejs.org/#template">_.template</a>
+      Так как на странице уже присутствует <a href="http://underscorejs.ru/">Underscore.js</a>,
+      доступная функция <a href="http://underscorejs.ru/#template">_.template</a>
       является превосходным выбором, если вы предпочитаете шаблоны с простыми включениями JavaScript.
     </p>
 
@@ -2838,7 +2838,7 @@ var model = localBackbone.Model.extend(...);
 
     <p>
       <b>Отрисовывайте UI</b>, как считаете нужным. Backbone ничего не знает о том, 
-      используете вы <a href="http://underscorejs.org/#template">шаблоны Underscore</a>,
+      используете вы <a href="http://underscorejs.ru/#template">шаблоны Underscore</a>,
       <a href="https://github.com/janl/mustache.js">Mustache.js</a>, прямые DOM-манипуляции,
       сгенерированные на сервере кусочки HTML или <a href="http://jqueryui.com/">jQuery UI</a>
       в методе <tt>render</tt>.
@@ -2998,8 +2998,8 @@ inbox.messages.fetch({reset: true});
       что когда функция передается как коллбэк, её оригинальный контекст (<tt>this</tt>) теряется.
       С Backbone, имея дело с <a href="#Events">событиями</a> и коллбэками,
       часто полезно полагаться на 
-      <a href="http://underscorejs.org/#bind">_.bind</a> и
-      <a href="http://underscorejs.org/#bindAll">_.bindAll</a>
+      <a href="http://underscorejs.ru/#bind">_.bind</a> и
+      <a href="http://underscorejs.ru/#bindAll">_.bindAll</a>
       из Underscore.js.
     </p>
 

--- a/index.html
+++ b/index.html
@@ -532,7 +532,7 @@
         <td><a class="punch" href="https://raw.github.com/jashkenas/backbone/master/backbone.js">Edge Version (master)</a></td>
         <td style="line-height: 18px;">
           <i>Последняя версия из репозитория, используйте на свой страх и риск</i>
-          <a class="travis-badge" href="https://travis-ci.org/documentcloud/backbone">
+          <a class="travis-badge" href="https://travis-ci.org/jashkenas/backbone">
             <img src="https://travis-ci.org/jashkenas/backbone.png" />
           </a>
         </td>


### PR DESCRIPTION
Привел ссылки на проект на travis-ci в соответствие с оригинальным сайтом документации. Сейчас на русском сайте эти ссылки битые.

Поменял ссылки на документацию underscore.js - с английской underscorejs.org на русскую underscorejs.ru.
